### PR TITLE
change boundaries of dependencies

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+# Handling DeprecationWarning 'asyncio_mode' default value
+[pytest]
+asyncio_mode = strict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 aiohttp>=3.8.1,<4
 fastapi>=0.78.0,<1
 pydantic>=1.9.1,<2
-starlette>=0.19.1,<1
 uvicorn>=0.17.6,<1
-requests>=2.27.1,<3
 websockets>=10.3,<11
 tenacity>=8.0.1,<9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-aiohttp>=3.7.2
-fastapi
-pydantic
-starlette>=0.13.6
-uvicorn
-requests>=2.25.0
-websockets
-tenacity>=6.3.1
+aiohttp>=3.8.1,<4
+fastapi>=0.78.0,<1
+pydantic>=1.9.1,<2
+starlette>=0.19.1,<1
+uvicorn>=0.17.6,<1
+requests>=2.27.1,<3
+websockets>=10.3,<11
+tenacity>=8.0.1,<9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-aiohttp>=3.8.1,<4
 fastapi>=0.78.0,<1
 pydantic>=1.9.1,<2
 uvicorn>=0.17.6,<1

--- a/tests/advanced_rpc_test.py
+++ b/tests/advanced_rpc_test.py
@@ -12,7 +12,6 @@ import pytest
 import uvicorn
 from fastapi import (APIRouter, Depends, FastAPI, Header, HTTPException,
                      WebSocket)
-from starlette import responses
 
 from fastapi_websocket_rpc.rpc_methods import RpcUtilityMethods
 from fastapi_websocket_rpc.websocket_rpc_client import WebSocketRpcClient


### PR DESCRIPTION
Now, every dependency has a minimum required version of the latest stable version, and is not allowed to upgrade to the next major version.