### PR TITLE
Permit pydantic v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Websockets are ideal to create bi-directional realtime connections over the web.
     - Server Endpoint:
         - Based on [FAST-API](https://github.com/tiangolo/fastapi): enjoy all the benefits of a full ASGI platform, including Async-io and dependency injections (for example to authenticate connections)
 
-        - Based on [Pydnatic](https://pydantic-docs.helpmanual.io/): easily serialize structured data as part of RPC requests and responses (see 'tests/basic_rpc_test.py :: test_structured_response' for an example)
+        - Based on [Pydantic](https://pydantic-docs.helpmanual.io/): easily serialize structured data as part of RPC requests and responses (see 'tests/basic_rpc_test.py :: test_structured_response' for an example)
 
     - Client :
         - Based on [Tenacity](https://tenacity.readthedocs.io/en/latest/index.html): allowing configurable retries to keep to connection alive

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi>=0.78.0,<1
-pydantic>=1.9.1,<2
+pydantic>=1.9.1
 uvicorn>=0.17.6,<1
 websockets>=10.3,<11
 tenacity>=8.0.1,<9


### PR DESCRIPTION
Unpin pydantic in the requirements to allow for v2. No breaking changes requiring migration