### PR TITLE
allow more recent websockets version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ fastapi>=0.78.0,<1
 packaging>=20.4
 pydantic>=1.9.1
 uvicorn>=0.17.6,<1
-websockets>=10.3,<11
+websockets>=10.3
 tenacity>=8.0.1,<9


### PR DESCRIPTION
Updates dependencies to allow a more recent websockets version.
See permitio/fastapi_websocket_pubsub#71.
