### PR TITLE
Remove WebsocketRPCEndpoint.on_connect

### DIFF
--- a/fastapi_websocket_rpc/websocket_rpc_endpoint.py
+++ b/fastapi_websocket_rpc/websocket_rpc_endpoint.py
@@ -107,14 +107,6 @@ class WebsocketRPCEndpoint:
         self.manager.disconnect(websocket)
         await channel.on_disconnect()
 
-    async def on_connect(self, channel, websocket):
-        """
-        Called upon new client connection
-        """
-        # Trigger connect callback if available
-        if (self._on_connect is not None):
-            asyncio.create_task(self._on_connect(channel, websocket))
-
     def register_route(self, router, path="/ws"):
         """
         Register this endpoint as a default websocket route on the given router


### PR DESCRIPTION
This method is never called and unused, likely left out from the cleanup after setting up `RpcChannel.register_connect_handler` (see for example a471d5488da07f54b1d559d009c51b56187c997b).

I thought that removal would be the best solution. Restoring the functionality would require to call it instead of the handlers passed at construction, which would be an odd choice given that there are no other customization methods (like e.g. `on_disconnect`) left in the class. Besides, any user of the class that is relying on it is currently *not* getting their method called.

This closes #39 .