### PR TITLE
Handle requests in a non-blocking fashion

### DIFF
--- a/fastapi_websocket_rpc/rpc_methods.py
+++ b/fastapi_websocket_rpc/rpc_methods.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import sys
+import time
 import typing
 import copy
 
@@ -97,3 +98,16 @@ class RpcUtilityMethods(RpcMethodsBase):
 
     async def echo(self, text: str) -> str:
         return text
+
+    async def wait(self, seconds: float) -> str:
+        await asyncio.sleep(seconds)
+        return "hello world"
+
+    async def time_me(self, method: str, args: dict, count: int) -> float:
+        tasks = set()
+        start = time.monotonic()
+        for i in range(count):
+            tasks.add(asyncio.create_task(self.channel.call(method, args=args)))
+        await asyncio.gather(*tasks)
+        end = time.monotonic()
+        return end - start


### PR DESCRIPTION
This means that long-running handler methods (if they are long-running due to a long `await`) will not prevent further incoming requests from being handled. This means your RPC handlers can use idiomatic Python (just `await` the thing you're waiting for, and `return` the result when you have it), rather than having to return as quickly as possible and schedule some notification to be sent back to the client when the result is available.

We still wait for all handlers to complete on shutdown.

Fixes #48