### PR TITLE
Move uvicorn to the tests dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 fastapi>=0.78.0,<1
 packaging>=20.4
 pydantic>=1.9.1
-uvicorn>=0.17.6,<1
 websockets>=10.3
 tenacity>=8.0.1,<9

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-asyncio
+uvicorn>=0.17.6,<1


### PR DESCRIPTION
`uvicorn` dependency is only used in the `tests` folder.

Fixes #25