### PR TITLE
Allow tenacity>=9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ fastapi>=0.78.0,<1
 packaging>=20.4
 pydantic>=1.9.1
 websockets>=10.3
-tenacity>=8.0.1,<9
+tenacity>=8.0.1


### PR DESCRIPTION
Hi,

Is there a reason the dependency on tenacity requires a version <9?

I did not notice any breakages when running the testsuite iwth tenacity=9.0.0, and the release notes also dont describe anything problematic: https://github.com/jd/tenacity/releases


Thanks, 

  Jorg 
